### PR TITLE
fix: Fix `client.load()` directory for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ By default, interactions.py does not allow you to send files in `CommandContext`
 
 You can load `interactions-files` like every other Extension by using:
 ```py
-client.load('interactions-ext-files')
+client.load('interactions.ext.files')
 ```
 
 After that, you can start sending files in Context. For example of doing this, go to [this](./examples).


### PR DESCRIPTION
Title and self-explanation.